### PR TITLE
options.silenced should be synced when not empty

### DIFF
--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -18,7 +18,7 @@ module Doggy
         attribute :locked,             Boolean
 
         def to_h
-          if monitor.id && monitor.loading_source == :local
+          if monitor.id && monitor.loading_source == :local && (!monitor.options || monitor.options.silenced.empty?)
             # Pull remote silenced state. If we don't send this value, Datadog
             # assumes that we want to unmute the monitor.
             remote_monitor = Monitor.find(monitor.id)


### PR DESCRIPTION
Fixes bug described at https://github.com/Shopify/dog/pull/1065#discussion_r90223701

@marc-barry @bai 