### PR TITLE
mute/unmute should change local objects too

### DIFF
--- a/lib/doggy/cli/mute.rb
+++ b/lib/doggy/cli/mute.rb
@@ -9,7 +9,7 @@ module Doggy
 
     def run
       monitors = @ids.map { |id| Doggy::Models::Monitor.find(id) }
-      monitors.each(&:mute)
+      monitors.each { |monitor| monitor.toggle_mute!('mute') }
     end
   end
 end

--- a/lib/doggy/cli/unmute.rb
+++ b/lib/doggy/cli/unmute.rb
@@ -9,7 +9,7 @@ module Doggy
 
     def run
       monitors = @ids.map { |id| Doggy::Models::Monitor.find(id) }
-      monitors.each(&:unmute)
+      monitors.each { |monitor| monitor.toggle_mute!('unmute') }
     end
   end
 end

--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -75,8 +75,8 @@ module Doggy
           Doggy.ui.error(message)
         else
           self.attributes = attributes
+          save_local
         end
-        save_local
       end
 
       def human_url

--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -69,7 +69,7 @@ module Doggy
       end
 
       def toggle_mute!(action)
-        return unless ['mute', 'unmute'].include?(action) || id
+        return unless ['mute', 'unmute'].include?(action) && id
         attributes = request(:post, "#{ resource_url(id) }/#{action}")
         if message = attributes['errors']
           Doggy.ui.error(message)

--- a/test/doggy/models/monitor_test.rb
+++ b/test/doggy/models/monitor_test.rb
@@ -1,0 +1,37 @@
+require_relative '../../test_helper'
+
+class Doggy::Models::DashboardTest < Minitest::Test
+  def test_toggle_mute
+    monitor = Doggy::Models::Monitor.new
+
+    assert_nil monitor.toggle_mute!('unmute')
+
+    monitor.id = 1
+    assert_nil monitor.toggle_mute!('something')
+
+    stub_request(:post, "https://app.datadoghq.com/api/v1/monitor/#{monitor.id}/mute?api_key=api_key_123&application_key=app_key_345").
+    to_return(status: 200, body: JSON.dump({'errors' => 'already muted'}))
+    Doggy.ui.expects(:error).with('already muted')
+    monitor.toggle_mute!('mute')
+  end
+
+  def test_mute
+    fixture = load_fixture('monitor.json')
+    monitor = Doggy::Models::Monitor.new(fixture)
+    stub_request(:post, "https://app.datadoghq.com/api/v1/monitor/#{monitor.id}/mute?api_key=api_key_123&application_key=app_key_345").
+    to_return(status: 200, body: JSON.dump(fixture.merge(options: fixture['options'].merge('silenced' => {'*' => nil}))))
+    monitor.expects(:save_local)
+    monitor.toggle_mute!('mute')
+    assert_equal monitor.options.silenced, {'*' => nil}
+  end
+
+  def test_unmute
+    fixture = load_fixture('monitor.json')
+    monitor = Doggy::Models::Monitor.new(fixture)
+    stub_request(:post, "https://app.datadoghq.com/api/v1/monitor/#{monitor.id}/unmute?api_key=api_key_123&application_key=app_key_345").
+    to_return(status: 200, body: JSON.dump(fixture.merge(options: fixture['options'].merge('silenced' => {}))))
+    monitor.expects(:save_local)
+    monitor.toggle_mute!('unmute')
+    assert_empty monitor.options.silenced
+  end
+end


### PR DESCRIPTION
Make sure mute/unmute commands change objects locally as well so that users can PR the change.

@marc-barry @bai 