### PR TITLE
some refactoring to avoid warnings and silenced logs for tests

### DIFF
--- a/lib/doggy.rb
+++ b/lib/doggy.rb
@@ -39,7 +39,7 @@ module Doggy
     current_dir = Dir.pwd
 
     while current_dir != '/' do
-      if File.exists?(File.join(current_dir, 'Gemfile')) then
+      if File.exist?(File.join(current_dir, 'Gemfile')) then
         return Pathname.new(current_dir)
       else
         current_dir = File.expand_path('../', current_dir)

--- a/lib/doggy/cli/pull.rb
+++ b/lib/doggy/cli/pull.rb
@@ -41,9 +41,9 @@ module Doggy
 
         # Here we traverse `remote_resources` to find remote resource with matching class name and id.
         # We cannot subtract `local_resources` from `remote_resources` because those are different kind of objects.
-        remote_resources_to_be_saved = normalized_resource_diff.map do |klass, id|
+        remote_resources_to_be_saved = normalized_resource_diff.map do |klass, normalized_resource_id|
           remote_resources.find do |rr|
-            rr.class.name == klass && rr.id == id
+            rr.class.name == klass && rr.id == normalized_resource_id
           end
         end
 

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -17,13 +17,7 @@ module Doggy
     attr_accessor :loading_source
 
     class << self
-      def root=(root)
-        @root = root.to_s
-      end
-
-      def root
-        @root || nil
-      end
+      attr_accessor :root
 
       def find(id)
         attributes = request(:get, resource_url(id))
@@ -177,7 +171,7 @@ module Doggy
 
     def save_local
       ensure_read_only!
-      @path ||= Doggy.object_root.join("#{prefix}-#{id}.json")
+      self.path ||= Doggy.object_root.join("#{prefix}-#{id}.json")
       File.open(@path, 'w') { |f| f.write(JSON.pretty_generate(to_h)) }
     end
 
@@ -198,10 +192,10 @@ module Doggy
         attributes = request(:post, resource_url, body)
         self.id    = self.class.new(attributes).id
         save_local
-        Doggy.ui.say "Created #{ @path }"
+        Doggy.ui.say "Created #{ path }"
       else
         request(:put, resource_url(id), body)
-        Doggy.ui.say "Updated #{ @path }"
+        Doggy.ui.say "Updated #{ path }"
       end
     end
 

--- a/test/doggy/model_test.rb
+++ b/test/doggy/model_test.rb
@@ -7,7 +7,7 @@ class Doggy::ModelTest < Minitest::Test
   end
 
   class DummyModelWithRoot < DummyModel
-    self.root = :dash
+    self.root = 'dash'
   end
 
   def test_save_local_ensures_read_only

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,7 @@ require 'webmock/minitest'
 class MiniTest::Test
   def before_setup
     Doggy.stubs(:secrets).returns({'datadog_api_key' => 'api_key_123', 'datadog_app_key' => 'app_key_345'})
+    Doggy.ui.stubs(:say)
     super
   end
 


### PR DESCRIPTION
The PR includes some minor refactoring to eliminate warning during test execution. It also makes sure `Dog.ui.say` is stubbed so that we don't have texts printed during test.

@Shopify/traffic @bai 