### PR TITLE
make sure mute/unmute changes the right local file

### DIFF
--- a/lib/doggy/cli/edit.rb
+++ b/lib/doggy/cli/edit.rb
@@ -8,7 +8,7 @@ module Doggy
     end
 
     def run
-      resource = resource_by_param
+      resource = Doggy::Model.find_local(@param)
       return Doggy.ui.error("Could not find resource with #{ @param }") unless resource
 
       forked_resource = fork(resource)
@@ -31,26 +31,7 @@ module Doggy
       forked_resource.destroy
     end
 
-  private
-
-    def resource_by_param
-      resources  = Doggy::Model.all_local_resources
-      if @param =~ /^[0-9]+$/ then
-        id = @param.to_i
-        return resources.find { |res| res.id == id }
-      elsif @param =~ /^http/ then
-        id = case @param
-          when /com\/dash/     then Integer(@param[/dash\/(\d+)/i, 1])
-          when /com\/screen/   then Integer(@param[/screen\/(\d+)/i, 1])
-          when /com\/monitors/ then Integer(@param[/monitors#(\d+)/i, 1])
-          else raise StandardError.new('Unknown resource type, cannot edit.')
-          end
-        return resources.find { |res| res.id == id }
-      else
-        full_path = File.expand_path(@param.gsub('objects/', ''), Doggy.object_root)
-        return resources.find { |res| res.path == full_path }
-      end
-    end
+    private
 
     def wait_for_edit
       while !Doggy.ui.yes?('Are you done editing?(Y/N)') do
@@ -82,4 +63,3 @@ module Doggy
     end
   end
 end
-

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -31,8 +31,20 @@ module Doggy
         resource
       end
 
+      def find_local(param)
+        resources  = Doggy::Model.all_local_resources
+        if (id = param).is_a?(Integer) || (param =~ /^[0-9]+$/ && id = Integer(param)) then
+          return resources.find { |res| res.id == id }
+        end
+        if id = param[/(dash\/|screen\/|monitors#)(\d+)/i, 2]
+          return resources.find { |res| res.id == Integer(id) }
+        end
+        full_path = File.expand_path(param.gsub('objects/', ''), Doggy.object_root)
+        resources.find { |res| res.path == full_path }
+      end
+
       def all_local_resources
-        @all_local_resources ||= Parallel.map((Dir[Doggy.object_root.join("**/*.json")])) do |file|
+        @@all_local_resources ||= Parallel.map(Dir[Doggy.object_root.join("**/*.json")]) do |file|
           raw = File.read(file, encoding: 'utf-8')
           begin
             attributes = JSON.parse(raw)

--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -75,6 +75,9 @@ module Doggy
           Doggy.ui.error(message)
         else
           self.attributes = attributes
+          if local_version = Doggy::Model.find_local(id)
+            self.path = local_version.path
+          end
           save_local
         end
       end

--- a/test/doggy/model_test.rb
+++ b/test/doggy/model_test.rb
@@ -10,6 +10,20 @@ class Doggy::ModelTest < Minitest::Test
     self.root = 'dash'
   end
 
+  def test_find_local
+    dashboard = Doggy::Models::Dashboard.new(load_fixture('dashboard.json'))
+    monitor= Doggy::Models::Monitor.new(load_fixture('monitor.json'))
+    monitor.path = File.join(Doggy.object_root, 'some-folder/monitor-22.json')
+    screen = Doggy::Models::Screen.new(load_fixture('screen.json'))
+    Doggy::Model.expects(:all_local_resources).times(6).returns([dashboard, monitor, screen])
+    assert_equal dashboard, Doggy::Model.find_local(2473)
+    assert_equal dashboard, Doggy::Model.find_local('2473')
+    assert_equal dashboard, Doggy::Model.find_local('https://app.datadoghq.com/dash/2473')
+    assert_equal monitor, Doggy::Model.find_local('https://app.datadoghq.com/monitors#22/edit')
+    assert_equal monitor, Doggy::Model.find_local('objects/some-folder/monitor-22.json')
+    assert_equal screen, Doggy::Model.find_local('https://app.datadoghq.com/screen/10/bbbb')
+  end
+
   def test_save_local_ensures_read_only
     monitor = Doggy::Models::Monitor.new(id: 1, title: 'Some test', name: 'Monitor name', options: {locked: false})
     monitor.path = Tempfile.new('monitor-1.json').path


### PR DESCRIPTION
`mute` and `unmute` commands were not editing the correct local object when object path was different than `dash|monitor|screen-id` format. The PR fixes that bug and refactors `resource_by_param` method.

@marc-barry 