### PR TITLE
fixes misspelled module name

### DIFF
--- a/lib/doggy/cli/push.rb
+++ b/lib/doggy/cli/push.rb
@@ -13,7 +13,7 @@ module Doggy
         if resource.is_deleted
           Doggy.ui.say "Deleting #{resource.path}, with id = #{resource.id}"
           resp = resource.destroy
-          Dog.ui.error("Could not delete. Error: #{resp['errors']}. Skipping") if resp['errors']
+          Doggy.ui.error("Could not delete. Error: #{resp['errors']}. Skipping") if resp['errors']
         else
           Doggy.ui.say "Saving #{resource.path}, with id = #{resource.id}"
           resource.ensure_read_only!


### PR DESCRIPTION
This https://shipit.shopify.io/shopify/dog/production/deploys/411489 deploy fails because an object that's been deleted in the relevant PR had already been deleted from Datadog. So Doggy sync is supposed to print a message in that case saying it is skipping that object, because it could not delete - but this was raising an error because module name was misspelled. The PR adds regression test and fix the spelling of the module.

@Shopify/traffic 