### PR TITLE
detect renames during sync

### DIFF
--- a/lib/doggy.rb
+++ b/lib/doggy.rb
@@ -23,6 +23,10 @@ module Doggy
 
   extend self
 
+  def random_word
+    (0...12).map { (97 + rand(26)).chr }.join
+  end
+
   def ui
     (defined?(@ui) && @ui) || (self.ui = Thor::Shell::Color.new)
   end

--- a/lib/doggy/cli/edit.rb
+++ b/lib/doggy/cli/edit.rb
@@ -40,7 +40,7 @@ module Doggy
     end
 
     def fork(resource)
-      salt = random_word
+      salt = Doggy.random_word
       forked_resource = resource.dup
       forked_resource.id = nil
       forked_resource.refute_read_only!
@@ -56,10 +56,6 @@ module Doggy
       end
       forked_resource.save
       forked_resource
-    end
-
-    def random_word
-      (0...12).map { (65 + rand(26)).chr.downcase }.join
     end
   end
 end

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -61,7 +61,9 @@ module Doggy
 
       def changed_resources
         repo = Rugged::Repository.new(Doggy.object_root.parent.to_s)
-        repo.diff(current_sha, 'HEAD').each_delta.map do |delta|
+        diff = repo.diff(current_sha, 'HEAD')
+        diff.find_similar!
+        diff.each_delta.map do |delta|
           new_file_path = delta.new_file[:path]
           next unless new_file_path.match(/\Aobjects\//)
           is_deleted = delta.status == :deleted
@@ -151,6 +153,10 @@ module Doggy
         raise NotImplementedError, "#resource_url has to be implemented."
       end
     end # class << self
+
+    def ==(another_model)
+      to_h == another_model.to_h
+    end
 
     def initialize(attributes = nil)
       root_key = self.class.root

--- a/test/doggy/cli/edit_test.rb
+++ b/test/doggy/cli/edit_test.rb
@@ -14,7 +14,7 @@ class Doggy::CLI::EditTest < Minitest::Test
       cmd = Doggy::CLI::Edit.new({}, resource.id.to_s)
 
       forked_resource_id = 2
-      cmd.expects(:random_word).returns('randomword')
+      Doggy.expects(:random_word).returns('randomword')
       forked_resource_attributes = resource.to_h.dup.merge(id: nil)
       if resource.is_a?(Doggy::Models::Dashboard)
         forked_resource_attributes.merge!(title: "[randomword] #{resource.title} \xF0\x9F\x90\xB6",

--- a/test/doggy/model_test.rb
+++ b/test/doggy/model_test.rb
@@ -62,7 +62,9 @@ class Doggy::ModelTest < Minitest::Test
       end
       screen.path = Doggy.object_root.parent.join("objects/new-folder/screen-#{screen.id}").to_s
       dashboard_to_delete.is_deleted = true
-      assert_equal [dashboard, monitor, screen, dashboard_to_delete].sort_by(&:id), Doggy::Model.changed_resources.sort_by(&:id)
+
+      assert_equal [dashboard, monitor, screen, dashboard_to_delete].sort_by(&:id),\
+        Doggy::Model.changed_resources.sort_by(&:id)
     ensure
       FileUtils.remove_entry(repo_root)
     end
@@ -159,13 +161,12 @@ class Doggy::ModelTest < Minitest::Test
   end
 
   def git_commit(repo)
-    random_word = (0...12).map { (65 + rand(26)).chr.downcase }.join
     options = {}
     options[:tree] = repo.index.write_tree(repo)
     options[:author] = { email: 'testuser@github.com', name: 'Test Author', time: Time.now }
     options[:committer] = { email: 'testuser@github.com', name: 'Test Author', time: Time.now }
-    options[:message] ||= "Making a commit via Rugged! #{random_word}"
-    options[:parents] = repo.empty? ? [] : [ repo.head.target ].compact
+    options[:message] = "Making a commit via Rugged! #{Doggy.random_word}"
+    options[:parents] = repo.empty? ? [] : [repo.head.target].compact
     options[:update_ref] = 'HEAD'
     Rugged::Commit.create(repo, options)
   end


### PR DESCRIPTION
fixes https://github.com/Shopify/doggy/issues/35

The issue is described in the above link extensively but tldr; is that `doggy sync` were not able to detect when an object gets renamed - it was thinking that the object at current path is deleted and the one in new path is a newly created object. As a result it was deleting the object from Datadog. `diff.find_similar!` fixes the issue - it detects renames and merge them into one `delta` with status `renamed`. The PR also adds regression test and plus full test coverage of `Doggy::Model.changed_resources` method.

@Shopify/traffic 