### PR TITLE
don't wait for errors key, always print response for delete action

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    doggy (2.0.35)
+    doggy (2.0.36)
       activesupport (~> 4)
       json (~> 1.8.3)
       parallel (~> 1.6.1)

--- a/lib/doggy/cli/push.rb
+++ b/lib/doggy/cli/push.rb
@@ -13,7 +13,7 @@ module Doggy
         if resource.is_deleted
           Doggy.ui.say "Deleting #{resource.path}, with id = #{resource.id}"
           resp = resource.destroy
-          Doggy.ui.error("Could not delete. Error: #{resp['errors']}. Skipping") if resp['errors']
+          Doggy.ui.say "Response: #{resp.inspect}"
         else
           Doggy.ui.say "Saving #{resource.path}, with id = #{resource.id}"
           resource.ensure_read_only!

--- a/lib/doggy/version.rb
+++ b/lib/doggy/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Doggy
-  VERSION = "2.0.35"
+  VERSION = '2.0.36'
 end

--- a/test/doggy/cli/push_test.rb
+++ b/test/doggy/cli/push_test.rb
@@ -30,16 +30,6 @@ class Doggy::CLI::PushTest < Minitest::Test
     Doggy::CLI::Push.new.sync_changes
   end
 
-  def test_sync_changes_when_destroy_fails
-    resource = Doggy::Models::Monitor.new(load_fixture('monitor.json'))
-    resource.is_deleted = true
-    Doggy::Model.expects(:changed_resources).returns([resource])
-    stub_request(:delete, "https://app.datadoghq.com/api/v1/#{resource.prefix}/#{resource.id}?api_key=api_key_123&application_key=app_key_345").
-      to_return(status: 200, body: JSON.dump(errors: "#{resource.id} has already been deleted."))
-    Doggy.ui.expects(:error).with("Could not delete. Error: #{resource.id} has already been deleted.. Skipping")
-    Doggy::CLI::Push.new.sync_changes
-  end
-
   def test_push_by_ids
     resources = prepare_for_push
     Doggy::CLI::Push.new.push_all(resources.map { |r| r.id.to_s })


### PR DESCRIPTION
For some reason Datadog API sometimes just returns `nil` when deleting an object, therefore this https://shipit.shopify.io/shopify/dog/production/deploys/412258 deploy failed. I removed the check and now always log the response message.

@Shopify/traffic 