### PR TITLE
Mute unmute by scope

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    doggy (2.0.36)
+    doggy (2.0.37)
       activesupport (~> 4)
       json (~> 1.8.3)
       parallel (~> 1.6.1)

--- a/lib/doggy/cli.rb
+++ b/lib/doggy/cli.rb
@@ -47,22 +47,26 @@ module Doggy
       CLI::Push.new.push_all(ids)
     end
 
-    desc "mute IDs [--duration DURATION]", "Mutes given monitors indefinitely or for the specific duration"
+    desc 'mute IDs [--duration DURATION]', 'Mutes given monitors indefinitely or for the specific duration'
     long_desc <<-D
       IDs is a space separated list of item IDs.
       If `--duration` is not given, item will be muted indefinitely.
     D
 
-    method_option "duration", type: :string, desc: 'Mute only for the given period of time.'
+    method_option 'duration', type: :string, desc: 'Mute only for the given period of time.'
+    method_option 'scope', type: :string, desc: 'The scope to apply the mute to.'
 
     def mute(*ids)
       CLI::Mute.new(options.dup, ids).run
     end
 
-    desc "unmute IDs", "Unmutes given monitors"
+    desc 'unmute IDs', 'Unmutes given monitors'
     long_desc <<-D
       IDs is a space separated list of item IDs.
     D
+
+    method_option 'scope', type: :string, desc: 'The scope to apply the unmute to.'
+    method_option 'all_scopes', type: :boolean, default: false, desc: 'Clear muting across all scopes.'
 
     def unmute(*ids)
       CLI::Unmute.new(options.dup, ids).run

--- a/lib/doggy/cli/mute.rb
+++ b/lib/doggy/cli/mute.rb
@@ -15,6 +15,7 @@ module Doggy
       if @options['duration']
         body[:end] = Time.now.utc.to_i + Duration.parse(@options['duration']).to_i
       end
+      body[:scope] = @options['scope'] if @options['scope']
       monitors.each { |monitor| monitor.toggle_mute!('mute', JSON.dump(body)) }
     end
   end

--- a/lib/doggy/cli/unmute.rb
+++ b/lib/doggy/cli/unmute.rb
@@ -4,14 +4,15 @@ module Doggy
   class CLI::Unmute
     def initialize(options, ids)
       @options = options
-      @ids     = ids
+      @ids = ids
     end
 
     def run
       monitors = @ids.map { |id| Doggy::Models::Monitor.find(id) }
-      monitors.each { |monitor| monitor.toggle_mute!('unmute') }
+      body = {}
+      body[:all_scopes] = true if @options['all_scopes']
+      body[:scope] = @options['scope'] if @options['scope']
+      monitors.each { |monitor| monitor.toggle_mute!('unmute', JSON.dump(body)) }
     end
   end
 end
-
-

--- a/lib/doggy/version.rb
+++ b/lib/doggy/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Doggy
-  VERSION = '2.0.36'
+  VERSION = '2.0.37'
 end

--- a/test/doggy/cli/mute_test.rb
+++ b/test/doggy/cli/mute_test.rb
@@ -2,18 +2,19 @@ require_relative '../../test_helper'
 
 class Doggy::CLI::MuteTest < Minitest::Test
   def test_run
-    monitor = Doggy::Models::Monitor.new(load_fixture('monitor.json'))
-    Doggy::Models::Monitor.expects(:find).with(monitor.id).returns(monitor)
-    monitor.expects(:toggle_mute!).with('mute', '{}')
-    Doggy::CLI::Mute.new({}, [monitor.id]).run
-  end
- 
-  def test_run_mute_with_duration
+    mocked_run
     now = Time.new(2020, 1, 1, 1, 1, 1, '+00:00')
-    Time.expects(:now).returns(now)
+    Time.expects(:now).twice.returns(now)
+    mocked_run({ 'duration' => '4h' }, { end: 1577854861 })
+    mocked_run({ 'duration' => '4h', 'scope' => 'role:db' }, { end: 1577854861, scope: 'role:db' })
+  end
+
+  private
+
+  def mocked_run(options = {}, body = {})
     monitor = Doggy::Models::Monitor.new(load_fixture('monitor.json'))
     Doggy::Models::Monitor.expects(:find).with(monitor.id).returns(monitor)
-    monitor.expects(:toggle_mute!).with('mute', JSON.dump({ end: 1577854861 }))
-    Doggy::CLI::Mute.new({ 'duration' => '4h' }, [monitor.id]).run
+    monitor.expects(:toggle_mute!).with('mute', JSON.dump(body))
+    Doggy::CLI::Mute.new(options, [monitor.id]).run
   end
 end

--- a/test/doggy/cli/unmute_test.rb
+++ b/test/doggy/cli/unmute_test.rb
@@ -1,0 +1,19 @@
+require_relative '../../test_helper'
+
+class Doggy::CLI::UnmuteTest < Minitest::Test
+  def test_run
+    mocked_run
+    mocked_run({ 'scope' => 'role:db' }, { scope: 'role:db' })
+    mocked_run({ 'all_scopes' => false }, {})
+    mocked_run({ 'all_scopes' => true }, { all_scopes: true })
+  end
+
+  private
+
+  def mocked_run(options = {}, body = {})
+    monitor = Doggy::Models::Monitor.new(load_fixture('monitor.json'))
+    Doggy::Models::Monitor.expects(:find).with(monitor.id).returns(monitor)
+    monitor.expects(:toggle_mute!).with('unmute', JSON.dump(body))
+    Doggy::CLI::Unmute.new(options, [monitor.id]).run
+  end
+end


### PR DESCRIPTION
Make sure all possible API parameters are supported for `mute` and `unmute` commands: http://docs.datadoghq.com/api/.

The PR adds `--scope` argument to both `mute` and `unmute` and it also adds `--all-scopes` parameter to `unmute` command.

@Shopify/traffic 