### PR TITLE
raise error on unexpected API response code

### DIFF
--- a/lib/doggy.rb
+++ b/lib/doggy.rb
@@ -21,6 +21,8 @@ module Doggy
   DOG_SKIP_REGEX         = /\xF0\x9F\x98\xB1|:scream:/i.freeze
   MANAGED_BY_DOGGY_REGEX = /\xF0\x9F\x90\xB6|:dog:/i.freeze
 
+  class DoggyError < StandardError; end
+
   extend self
 
   def random_word

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -112,6 +112,9 @@ module Doggy
         request.body = body if body
 
         response = http.request(request)
+        unless response.code =~ /\A[23][0-9]{2}\Z/
+          raise DoggyError, "Unexpected response code #{response.code} for #{url}."
+        end
         response.body ? JSON.parse(response.body) : nil
       end
 

--- a/test/doggy/model_test.rb
+++ b/test/doggy/model_test.rb
@@ -101,9 +101,20 @@ class Doggy::ModelTest < Minitest::Test
     model = Doggy::Models::Dashboard.new({'dash' => {'title' => 'Pipeline', 'read_only' => true}})
     stub_request(:post, 'https://app.datadoghq.com/api/v1/dash?api_key=api_key_123&application_key=app_key_345').
         with(:body => "{\"description\":null,\"graphs\":[],\"id\":null,\"read_only\":true,\"template_variables\":[],\"title\":\"Pipeline 🐶\"}").
-                      to_return(:status => 200, :body => "{\"id\":1}")
+                      to_return(:status => 201, :body => "{\"id\":1}")
     File.expects(:open).with(Doggy.object_root.join('dash-1.json'), 'w')
     model.save
+  end
+
+  def test_create_when_api_error
+    model = Doggy::Models::Dashboard.new({'dash' => {'title' => 'Pipeline', 'read_only' => true}})
+    stub_request(:post, 'https://app.datadoghq.com/api/v1/dash?api_key=api_key_123&application_key=app_key_345').
+        with(:body => "{\"description\":null,\"graphs\":[],\"id\":null,\"read_only\":true,\"template_variables\":[],\"title\":\"Pipeline 🐶\"}").
+                      to_return(:status => 400, :body => "{}")
+    File.expects(:open).with(Doggy.object_root.join('dash-1.json'), 'w').times(0)
+    assert_raises Doggy::DoggyError do
+      model.save
+    end
   end
 
   def test_update


### PR DESCRIPTION
Doggy was not raising any error when it was getting unexpected response code, i.e this https://shipit.shopify.io/shopify/dog/production/deploys/421470 is one of the deploys that "push" did not work but deploy was actually successful(I added debug statement it was actually returning `400`). So I added a condition to raise an exception if status is not 2** or 3**.

@Shopify/traffic 