### PR TITLE
Fail on return code

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    doggy (2.0.37)
+    doggy (2.0.39)
       activesupport (~> 4)
       json (~> 1.8.3)
       parallel (~> 1.6.1)
@@ -12,9 +12,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.7.1)
+    activesupport (4.2.8)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
@@ -32,9 +31,9 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     equalizer (0.0.11)
     hashdiff (0.2.3)
-    i18n (0.7.0)
+    i18n (0.8.1)
     ice_nine (0.11.2)
-    json (1.8.3)
+    json (1.8.6)
     metaclass (0.0.4)
     minitest (5.9.0)
     mocha (1.1.0)
@@ -45,7 +44,7 @@ GEM
     rugged (0.23.3)
     safe_yaml (1.0.4)
     thor (0.19.4)
-    thread_safe (0.3.5)
+    thread_safe (0.3.6)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     virtus (1.0.5)
@@ -70,4 +69,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/lib/doggy/cli/push.rb
+++ b/lib/doggy/cli/push.rb
@@ -3,8 +3,8 @@
 module Doggy
   class CLI::Push
     WARNING_MESSAGE = "You are about to force push all the objects. "\
-      "This will override changes in Datadog if they have not been sycned to the dog repository. "\
-      "Do you want to proceed?(Y/N)"
+      "This will override changes in Datadog if they have not been synced to the dog repository. "\
+      "Do you want to proceed? (Y/N)"
 
     def sync_changes
       changed_resources = Doggy::Model.changed_resources

--- a/lib/doggy/model.rb
+++ b/lib/doggy/model.rb
@@ -23,8 +23,7 @@ module Doggy
       attr_accessor :root
 
       def find(id)
-        attributes = nil
-        attributes = request(:get, resource_url(id), [404])
+        attributes = request(:get, resource_url(id), nil, [404])
         return if attributes['errors']
         resource   = new(attributes)
 

--- a/lib/doggy/version.rb
+++ b/lib/doggy/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Doggy
-  VERSION = '2.0.38'
+  VERSION = '2.0.39'
 end

--- a/test/doggy/model_test.rb
+++ b/test/doggy/model_test.rb
@@ -126,6 +126,18 @@ class Doggy::ModelTest < Minitest::Test
     model.save
   end
 
+  def test_find_missing
+    stub_test_find(400)
+    assert_raises Doggy::DoggyError do
+      Doggy::Models::Monitor.find(1)
+    end
+  end
+
+  def test_find_success
+    stub_test_find(404)
+    Doggy::Models::Monitor.find(1)
+  end
+
   def test_sort_by_key
     h = { b: [ {d: 1, a: 2}, {x: 1, p: 3, y: 5} ], a: 3 }
     expected = { a: 3, b: [ {a: 2, d: 1}, {p: 3, x: 1, y: 5} ] }
@@ -164,6 +176,13 @@ class Doggy::ModelTest < Minitest::Test
   end
 
   private
+
+  def stub_test_find(return_code)
+    Doggy::Models::Monitor.new(id: 1, title: 'Some test', name: 'Monitor name')
+    stub_request(:get, "https://app.datadoghq.com/api/v1/monitor/1?api_key=api_key_123&application_key=app_key_345").
+      with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type'=>'application/json', 'User-Agent'=>'Ruby'}).
+      to_return(:status => return_code, :body => "{\"errors\":[]}", :headers => {})
+  end
 
   def git_create(repo, path, content)
     oid = repo.write(content, :blob)


### PR DESCRIPTION
This PR reintroduces https://github.com/Shopify/doggy/pull/42, while allowing `find` to receive a `404`.

Doggy must absolutely *fail* if it cannot sync correctly, otherwise it will fail to update dashboards/monitors with syntax errors, which can cause severe ops disruptions.

Resolves: https://github.com/Shopify/doggy/issues/43