### PR TITLE
Add monitor missing attributes

### DIFF
--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -6,19 +6,19 @@ module Doggy
       class Options
         include Virtus.model
 
-        attribute :silenced,           Hash
-        attribute :thresholds,         Hash
-        attribute :notify_audit,       Boolean
-        attribute :notify_no_data,     Boolean
-        attribute :no_data_timeframe,  Integer
-        attribute :timeout_h,          Integer
-        attribute :escalation_message, String
-        attribute :renotify_interval,  Integer
-        attribute :locked,             Boolean
-        attribute :include_tags,       Boolean
-        attribute :require_full_window,Boolean
-        attribute :new_host_delay,     Integer
-        attribute :evaluation_delay,   Integer
+        attribute :escalation_message,  String
+        attribute :evaluation_delay,    Integer
+        attribute :include_tags,        Boolean
+        attribute :locked,              Boolean
+        attribute :new_host_delay,      Integer
+        attribute :no_data_timeframe,   Integer
+        attribute :notify_audit,        Boolean
+        attribute :notify_no_data,      Boolean
+        attribute :renotify_interval,   Integer
+        attribute :require_full_window, Boolean
+        attribute :silenced,            Hash
+        attribute :thresholds,          Hash
+        attribute :timeout_h,           Integer
       end
 
       attribute :id,     Integer

--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -15,6 +15,10 @@ module Doggy
         attribute :escalation_message, String
         attribute :renotify_interval,  Integer
         attribute :locked,             Boolean
+        attribute :include_tags,       Boolean
+        attribute :require_full_window,Boolean
+        attribute :new_host_delay,     Integer
+        attribute :evaluation_delay,   Integer
       end
 
       attribute :id,     Integer


### PR DESCRIPTION
I'm not sure if there was a reason for these to be excluded, but I needed at least `evaluation_delay`. 

We could probably add a warning of some sort when "ignoring" unexpected attributes (eg.: if new ones are added) but that is somewhat out of scope here.

```rb
 +        attribute :include_tags,       Boolean
 +        attribute :require_full_window,Boolean
 +        attribute :new_host_delay,     Integer
 +        attribute :evaluation_delay,   Integer
```

This is what the api returns:
```json
{
  "tags": [
    "*"
  ],
  "deleted": null,
  "query": "avg(last_15m):anomalies(avg:Something{*}.as_count(), 'basic', 2, direction='both') > 0.3",
  "message": "This is a test",
  "id": 9999999,
  "multi": false,
  "name": "TEST",
  "created": "2017-09-11T12:47:14.597990+00:00",
  "created_at": 1505134034000,
  "creator": {
    "id": 99999,
    "handle": "thierry.joyal@shopify.com",
    "name": "Thierry Joyal",
    "email": "thierry.joyal@shopify.com"
  },
  "org_id": 99999,
  "modified": "2017-09-11T12:47:14.597990+00:00",
  "overall_state_modified": "2017-09-11T12:47:23.347480+00:00",
  "overall_state": "OK",
  "type": "query alert",
  "options": {
    "notify_audit": false,
    "locked": false,
    "timeout_h": 0,
    "silenced": {},
    "include_tags": false,
    "no_data_timeframe": 10,
    "require_full_window": true,
    "new_host_delay": 300,
    "notify_no_data": false,
    "renotify_interval": 0,
    "evaluation_delay": 60,
    "escalation_message": "",
    "thresholds": {
      "critical": 0.3
    }
  }
}
```

I only added the missing "options", but should we also add others like "deleted"?