### PR TITLE
Bump doggy version to 2.0.41.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    doggy (2.0.40)
+    doggy (2.0.41)
       activesupport (~> 4)
       json (~> 1.8.3)
       parallel (~> 1.6.1)
@@ -12,7 +12,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.8)
+    activesupport (4.2.9)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -31,7 +31,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.1)
     equalizer (0.0.11)
     hashdiff (0.2.3)
-    i18n (0.8.1)
+    i18n (0.8.6)
     ice_nine (0.11.2)
     json (1.8.6)
     metaclass (0.0.4)
@@ -45,7 +45,7 @@ GEM
     safe_yaml (1.0.4)
     thor (0.19.4)
     thread_safe (0.3.6)
-    tzinfo (1.2.2)
+    tzinfo (1.2.3)
       thread_safe (~> 0.1)
     virtus (1.0.5)
       axiom-types (~> 0.1)
@@ -69,4 +69,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.14.4
+   1.15.0

--- a/lib/doggy/version.rb
+++ b/lib/doggy/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Doggy
-  VERSION = '2.0.40'
+  VERSION = '2.0.41'
 end


### PR DESCRIPTION
@Shopify/edgescale, @tjoyal 

Related: https://github.com/Shopify/vendor-datadog/issues/3, https://github.com/Shopify/dog/pull/2448

This is to pick up #46.

https://github.com/Shopify/doggy/releases/tag/v2.0.41