### PR TITLE
Add support for a base url if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ To authenticate, you need to set API and APP keys for your DataDog account.
 
 Export `DATADOG_API_KEY` and `DATADOG_APP_KEY` environment variables and `doggy` will catch them up automatically.
 
+Optional: You can set `DATADOG_BASE_HUMAN_URL` environment variable if your organization uses a custom domain. This will change the urls given to users.
+
 #### ejson
 
 Set up `ejson` by putting `secrets.ejson` in your root object store.
@@ -42,6 +44,8 @@ If you're feeling adventurous, just put plaintext `secrets.json` in your root ob
   "datadog_app_key": "key2"
 }
 ```
+
+Optional: Add `datadog_base_human_url` if your organization uses a custom domain.
 
 ## Usage
 

--- a/lib/doggy.rb
+++ b/lib/doggy.rb
@@ -54,6 +54,10 @@ module Doggy
     end
   end
 
+  def base_human_url
+    ENV['DATADOG_BASE_HUMAN_URL'] || secrets['datadog_base_human_url'] || 'app.datadoghq.com'
+  end
+
   def api_key
     ENV['DATADOG_API_KEY'] || secrets['datadog_api_key']
   end

--- a/lib/doggy/models/dashboard.rb
+++ b/lib/doggy/models/dashboard.rb
@@ -42,7 +42,7 @@ module Doggy
       end
 
       def human_url
-        "https://app.datadoghq.com/dash/#{ id }"
+        "https://#{Doggy.base_human_url}/dash/#{ id }"
       end
 
       # Dashboards don't have a direct edit URL

--- a/lib/doggy/models/monitor.rb
+++ b/lib/doggy/models/monitor.rb
@@ -87,11 +87,11 @@ module Doggy
       end
 
       def human_url
-        "https://app.datadoghq.com/monitors##{ id }"
+        "https://#{Doggy.base_human_url}/monitors##{ id }"
       end
 
       def human_edit_url
-        "https://app.datadoghq.com/monitors##{ id }/edit"
+        "https://#{Doggy.base_human_url}/monitors##{ id }/edit"
       end
 
       def to_h

--- a/lib/doggy/models/screen.rb
+++ b/lib/doggy/models/screen.rb
@@ -43,7 +43,7 @@ module Doggy
       end
 
       def human_url
-        "https://app.datadoghq.com/screen/#{ id }"
+        "https://#{Doggy.base_human_url}/screen/#{ id }"
       end
 
       # Screens don't have a direct edit URL


### PR DESCRIPTION
Fixes #48 

Some organizations use a special subdomain like `org.datadoghq.com`. This change allows the users of this gem to specify via secrets or the ENV var, just like `DATADOG_API_KEY`

